### PR TITLE
RTK Improvements and Manual Entry

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -303,11 +303,11 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		return -1;
 	}
 
-	if (output_mode == OutputMode::RTCM) {
-		if (restartSurveyIn() < 0) {
-			return -1;
-		}
-	}
+    if (output_mode == OutputMode::RTCM && _buf.payload_rx_nav_svin.meanAcc <= 0) {
+        if (restartSurveyIn() < 0) {
+            return -1;
+        }
+    }
 
 	_configured = true;
 	return 0;

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -305,8 +305,6 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		return -1;
 	}
 
-    qDebug() << "Reached disable time mode";
-
     if (disableTimeMode() < 0) {
         return -1;
     }

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -303,7 +303,7 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		return -1;
 	}
 
-    if (output_mode == OutputMode::RTCM && _buf.payload_rx_nav_svin.meanAcc <= 0) {
+    if (_resetSurveyIn) {
         if (restartSurveyIn() < 0) {
             return -1;
         }
@@ -326,16 +326,16 @@ int GPSDriverUBX::restartSurveyIn()
 
 	//stop it first
 	//FIXME: stopping the survey-in process does not seem to work
-	memset(&_buf.payload_tx_cfg_tmode3, 0, sizeof(_buf.payload_tx_cfg_tmode3));
-	_buf.payload_tx_cfg_tmode3.flags        = 0; /* disable time mode */
+    memset(&_buf.payload_tx_cfg_tmode3, 0, sizeof(_buf.payload_tx_cfg_tmode3));
+    _buf.payload_tx_cfg_tmode3.flags = 0; /* disable time mode */
 
-	if (!sendMessage(UBX_MSG_CFG_TMODE3, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_tmode3))) {
-		return -1;
-	}
+    if (!sendMessage(UBX_MSG_CFG_TMODE3, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_tmode3))) {
+        return -1;
+    }
 
-	if (waitForAck(UBX_MSG_CFG_TMODE3, UBX_CONFIG_TIMEOUT, true) < 0) {
-		return -1;
-	}
+    if (waitForAck(UBX_MSG_CFG_TMODE3, UBX_CONFIG_TIMEOUT, true) < 0) {
+        return -1;
+    }
 
 	UBX_DEBUG("Starting Survey-in");
 
@@ -1402,9 +1402,10 @@ GPSDriverUBX::fnv1_32_str(uint8_t *str, uint32_t hval)
 }
 
 void
-GPSDriverUBX::setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur)
+GPSDriverUBX::setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur, bool resetSurveyIn)
 {
-	_survey_in_acc_limit = survey_in_acc_limit;
-	_survey_in_min_dur = survey_in_min_dur;
+    _survey_in_acc_limit    = survey_in_acc_limit;
+    _survey_in_min_dur      = survey_in_min_dur;
+    _resetSurveyIn          = resetSurveyIn;
 }
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -171,6 +171,7 @@
 
 /* TX CFG-TMODE3 message contents */
 #define UBX_TX_CFG_TMODE3_FLAGS     	1 	    	/**< start survey-in */
+#define UBX_TX_CFG_TMODE3_FIXEDLLA      258
 #define UBX_TX_CFG_TMODE3_SVINMINDUR    (3*60)		/**< survey-in: minimum duration [s] (higher=higher precision) */
 #define UBX_TX_CFG_TMODE3_SVINACCLIMIT  (10000)	/**< survey-in: position accuracy limit 0.1[mm] */
 
@@ -575,9 +576,12 @@ public:
 	virtual ~GPSDriverUBX();
 	int receive(unsigned timeout);
 	int configure(unsigned &baudrate, OutputMode output_mode);
-    void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur, bool resetSurveyIn);
+    void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur);
+    void setFixedSurveyLLA(double latitude, double longitude, double altitude);
 
+    int disableTimeMode();
 	int restartSurveyIn();
+    int enableFixedLLA();
 private:
 
 	/**
@@ -671,7 +675,11 @@ private:
 	const Interface		_interface;
 	uint32_t _survey_in_acc_limit;
 	uint32_t _survey_in_min_dur;
-    bool     _resetSurveyIn;
+
+    int32_t _fixed_survey_latitude;
+    int32_t _fixed_survey_longitude;
+    int32_t _fixed_survey_altitude;
+
 };
 
 #endif /* UBX_H_ */

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -577,7 +577,7 @@ public:
 	int receive(unsigned timeout);
 	int configure(unsigned &baudrate, OutputMode output_mode);
     void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur);
-    void setFixedSurveyLLA(double latitude, double longitude, double altitude);
+    void setFixedSurveyLLA(int32_t latitude, int32_t longitude, int32_t altitude, int8_t latitudeHP, int8_t longitudeHP, int8_t altitudeHP);
 
     int disableTimeMode();
 	int restartSurveyIn();
@@ -679,6 +679,10 @@ private:
     int32_t _fixed_survey_latitude;
     int32_t _fixed_survey_longitude;
     int32_t _fixed_survey_altitude;
+
+    int8_t  _fixed_survey_latitudeHP;
+    int8_t  _fixed_survey_longitudeHP;
+    int8_t  _fixed_survey_altitudeHP;
 
 };
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -575,7 +575,7 @@ public:
 	virtual ~GPSDriverUBX();
 	int receive(unsigned timeout);
 	int configure(unsigned &baudrate, OutputMode output_mode);
-	void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur);
+    void setSurveyInSpecs(uint32_t survey_in_acc_limit, uint32_t survey_in_min_dur, bool resetSurveyIn);
 
 	int restartSurveyIn();
 private:
@@ -671,6 +671,7 @@ private:
 	const Interface		_interface;
 	uint32_t _survey_in_acc_limit;
 	uint32_t _survey_in_min_dur;
+    bool     _resetSurveyIn;
 };
 
 #endif /* UBX_H_ */


### PR DESCRIPTION
This PR alters the UBX8 GPS drivers in a way that allows a user finer control over what happens when setting up an RTK base station.

In particular, it allows the user to restart Survey-In manually (and only manually, it will not restart automatically on reconnect), as well as allowing the user to set a fixed location (LLA) for an RTK base station.